### PR TITLE
Handle Sqlite DSN separators

### DIFF
--- a/src/DSN.php
+++ b/src/DSN.php
@@ -163,7 +163,7 @@ final class DSN
         }
 
         // Remove the protocol
-        $dsn = str_replace($this->protocol.'://', '', $dsn);
+        $dsn = ltrim(str_replace($this->protocol, '', $dsn), ':/');
 
         // Parse and remove auth if they exist
         if (false === $pos = strrpos($dsn, '@')) {
@@ -190,8 +190,12 @@ final class DSN
             }
         }
 
-        $temp = explode('/', $dsn);
-        $this->parseHosts($temp[0]);
+        if ('sqlite' === $this->protocol) {
+            $this->hosts[] = ['host' => null, 'port' => null];
+        } else {
+            $temp = explode('/', $dsn);
+            $this->parseHosts($temp[0]);
+        }
 
         if (isset($temp[1])) {
             $params = $temp[1];

--- a/tests/DsnTest.php
+++ b/tests/DsnTest.php
@@ -29,6 +29,28 @@ class DsnTest extends TestCase
         $this->assertEquals('root_pass', $auth['password']);
     }
 
+    public function testSqlite()
+    {
+        $inputString = 'sqlite:///root:root_pass@127.0.0.1/test.db';
+        $dsn = new DSN($inputString);
+
+        $this->assertTrue($dsn->isValid());
+        $this->assertEquals('sqlite', $dsn->getProtocol());
+        $this->assertEquals('root', $dsn->getUsername());
+        $this->assertEquals('root_pass', $dsn->getPassword());
+        $this->assertEquals('127.0.0.1', $dsn->getFirstHost());
+        $this->assertEquals(null, $dsn->getFirstPort());
+        $this->assertEquals('test.db', $dsn->getDatabase());
+        $this->assertEquals($inputString, $dsn->getDsn());
+
+        $auth = $dsn->getAuthentication();
+        $this->assertArrayHasKey('username', $auth);
+        $this->assertArrayHasKey('password', $auth);
+
+        $this->assertEquals('root', $auth['username']);
+        $this->assertEquals('root_pass', $auth['password']);
+    }
+
     public function testParameters()
     {
         $dsn = new DSN('mysql://127.0.0.1/test_db?foo=bar&baz=biz&aa');


### PR DESCRIPTION
The Sqlite DSN has a 3-slash separator format — `sqlite:///` — as opposed to the 2-slash of other platforms.