### PR TITLE
Decode parameters in URL

### DIFF
--- a/src/DSN.php
+++ b/src/DSN.php
@@ -174,10 +174,10 @@ final class DSN
 
             $auth = [];
             if (2 === count($temp)) {
-                $auth['username'] = $temp[0];
-                $auth['password'] = $temp[1];
+                $auth['username'] = rawurldecode($temp[0]);
+                $auth['password'] = rawurldecode($temp[1]);
             } else {
-                $auth['username'] = $temp[0];
+                $auth['username'] = rawurldecode($temp[0]);
                 $auth['password'] = null;
             }
 
@@ -196,7 +196,7 @@ final class DSN
         if (isset($temp[1])) {
             $params = $temp[1];
             $temp = explode('?', $params);
-            $this->database = empty($temp[0]) ? null : $temp[0];
+            $this->database = empty($temp[0]) ? null : rawurldecode($temp[0]);
             if (isset($temp[1])) {
                 $this->parseParameters($temp[1]);
             }

--- a/tests/DsnTest.php
+++ b/tests/DsnTest.php
@@ -58,6 +58,7 @@ class DsnTest extends TestCase
     {
         return [
             ['mysql://root:root_pass@127.0.0.1:3306/test_db', 'root', 'root_pass', 'username', 'password'],
+            ['mysql://root:aA%263yuA%3F123-2ABC@127.0.0.1:3306/test_db', 'root', 'aA&3yuA?123-2ABC', 'username', 'password'],
             ['mysql://127.0.0.1:3306/test_db', null, null, 'username', 'password'],
         ];
     }


### PR DESCRIPTION
A DSN is a URL and therefore URL-encoded. The DSN parser, therefore, needs to decode parameters with a potential of special characters: database name, user, password.

Take for example the following URL:
`mysql://test:aA%263yuA%3F123-2ABC@127.0.0.1:8889/test`
The correct password for this DSN is `aA&3yuA?123-2ABC`.

This PR fixes the parsing of DSNs with special characters, i.e. urlencoded URLs.